### PR TITLE
Updating package name and app title on Android

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
-<manifest package="vedder.vesctool" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="3.01" android:versionCode="95" android:installLocation="auto">
-    <application android:hardwareAccelerated="true" android:name="org.qtproject.qt5.android.bindings.QtApplication" android:label="VESC Tool" android:icon="@drawable/icon" android:requestLegacyExternalStorage="true">
-        <activity android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation" android:name="org.qtproject.qt5.android.bindings.QtActivity" android:label="VESC Tool" android:screenOrientation="unspecified" android:launchMode="singleTop">
+<manifest package="vedder.vesctool.atr" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="3.01" android:versionCode="108" android:installLocation="auto">
+    <application android:hardwareAccelerated="true" android:name="org.qtproject.qt5.android.bindings.QtApplication" android:label="VESC Tool (ATR)" android:icon="@drawable/icon" android:requestLegacyExternalStorage="true">
+        <activity android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation" android:name="org.qtproject.qt5.android.bindings.QtActivity" android:label="VESC Tool (ATR)" android:screenOrientation="unspecified" android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
@@ -71,7 +71,7 @@
 
     </application>
 
-    <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="29"/>
+    <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="30"/>
     <supports-screens android:largeScreens="true" android:normalScreens="true" android:anyDensity="true" android:smallScreens="true"/>
 
     <!-- The following comment will be replaced upon deployment with default permissions based on the dependencies of the application.

--- a/android/AndroidManifest.xml.in
+++ b/android/AndroidManifest.xml.in
@@ -1,7 +1,7 @@
 <?xml version='"1.0"'?>
-<manifest package='"vedder.vesctool"' xmlns:android='"http://schemas.android.com/apk/res/android"' android:versionName='"$$VT_VERSION"' android:versionCode='"$${VT_ANDROID_VERSION}"' android:installLocation='"auto"'>
-    <application android:hardwareAccelerated='"true"' android:name='"org.qtproject.qt5.android.bindings.QtApplication"' android:label='"VESC Tool"' android:icon='"@drawable/icon"' android:requestLegacyExternalStorage='"true"'>
-        <activity android:configChanges='"orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation"' android:name='"org.qtproject.qt5.android.bindings.QtActivity"' android:label='"VESC Tool"' android:screenOrientation='"unspecified"' android:launchMode='"singleTop"'>
+<manifest package='"vedder.vesctool.atr"' xmlns:android='"http://schemas.android.com/apk/res/android"' android:versionName='"$$VT_VERSION"' android:versionCode='"$${VT_ANDROID_VERSION}"' android:installLocation='"auto"'>
+    <application android:hardwareAccelerated='"true"' android:name='"org.qtproject.qt5.android.bindings.QtApplication"' android:label='"VESC Tool (ATR)"' android:icon='"@drawable/icon"' android:requestLegacyExternalStorage='"true"'>
+        <activity android:configChanges='"orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation"' android:name='"org.qtproject.qt5.android.bindings.QtActivity"' android:label='"VESC Tool (ATR)"' android:screenOrientation='"unspecified"' android:launchMode='"singleTop"'>
             <intent-filter>
                 <action android:name='"android.intent.action.MAIN"'/>
                 <category android:name='"android.intent.category.LAUNCHER"'/>

--- a/android/src/com/vedder/vesc/VForegroundService.java
+++ b/android/src/com/vedder/vesc/VForegroundService.java
@@ -28,7 +28,7 @@ import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.os.Build;
 
-import vedder.vesctool.R;
+import vedder.vesctool.atr.R;
 
 public class VForegroundService extends Service {
     public static final String ACTION_START_FOREGROUND_SERVICE = "ACTION_START_FOREGROUND_SERVICE";


### PR DESCRIPTION
Signed-off-by: Grafalgar <grafalgar@gmail.com>

Allows the ATR-specific version of the vesc-tool to be installed side-by-side to official vesc app.  Done simply by changing the package name and adding "(ATR)" to the end of the app title, so they can be differentiated.